### PR TITLE
Removed unnecessary class name

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -84,7 +84,7 @@ const NavBar = () => {
   }, [showMenu])
 
   return (
-    <StyledDiv className={showMenu ? "extended-menu" : "normal-menu"} extended={showMenu}>
+    <StyledDiv extended={showMenu}>
       <StyledWebsiteTitleBar>
         <StyledWebsiteTitle>{websiteTitle}</StyledWebsiteTitle>
       </StyledWebsiteTitleBar>


### PR DESCRIPTION
Removed unnecessary class name. It was once used in an outdated implementation of the navigation bar