### PR TITLE
Reverted back to uppercase letters for hex codes

### DIFF
--- a/src/components/styles/NavBar.styled.ts
+++ b/src/components/styles/NavBar.styled.ts
@@ -52,11 +52,11 @@ export const StyledLink = styled(Link)`
   color: black;
 
   &:hover {
-    color: #9090ff;
+    color: #9090FF;
   }
 
   &:active {
-    color: #ccccff;
+    color: #CCCCFF;
   }
 
   @media only screen and (max-width: 800px) {
@@ -139,10 +139,10 @@ export const StyledMobileLink = styled(Link)`
   color: black;
 
   &:hover {
-    color: #9090ff;
+    color: #9090FF;
   }
 
   &:active {
-    color: #ccccff;
+    color: #CCCCFF;
   }
 `


### PR DESCRIPTION
For consistent code style, the letters in hex codes are uppercase. They were accidentally made lowercase in #17