### PR TITLE
Made navigation bar cover content when scrolled

### DIFF
--- a/src/components/styles/NavBar.styled.ts
+++ b/src/components/styles/NavBar.styled.ts
@@ -8,6 +8,7 @@ export const StyledDiv = styled.div<{ showMenu: boolean }>`
   position: sticky;
   top: -90px;
   background-color: white;
+  z-index: 1;
 
   @media only screen and (max-width: 800px) {
     max-height: ${(props) => (props.showMenu ? "100vh" : "60px")};


### PR DESCRIPTION
Navigation bar will now take priority over overlapping elements that are not meant to cover it