### PR TITLE
SEO and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ public
 src/gatsby-types.d.ts
 
 # Temporary placeholders
-src/images/placeholders
+**/placeholders
 
 # Miscellaneous
 .DS_Store

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,27 +1,44 @@
-import type { GatsbyConfig } from "gatsby";
+import type { GatsbyConfig } from "gatsby"
 
 const config: GatsbyConfig = {
   siteMetadata: {
-    title: `Mika Okabe Portfolio`,
-    siteUrl: `https://www.yourdomain.tld`
+    title: `Mika's Portfolio`,
+    description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Curabitur eget diam id sapien interdum posuere. Maecenas
+                  vitae sem sed nulla malesuada aliquet in quis ligula. Sed
+                  commodo ornare magna libero.`,
+    author: `Mika Okabe`,
+    creator: `Jarell Santella`,
+    type: `website`,
+    siteUrl: `https://mikaokabe.com`,
+    keywords: `artist, art, storyboard, animation, portfolio, panels, tv,
+               television, commission, freelance, film, beats, illustration`,
+    openGraphImage: `/images/1200x630placeholder.png`,
+    twitterImage: `/images/1200x600placeholder.png`,
+    twitterUsername: `@wishterias`,
   },
-  // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
-  // If you use VSCode you can also use the GraphQL plugin
-  // Learn more at: https://gatsby.dev/graphql-typegen
   graphqlTypegen: true,
-  plugins: ["gatsby-plugin-styled-components", "gatsby-plugin-image", "gatsby-plugin-sitemap", {
-    resolve: 'gatsby-plugin-manifest',
-    options: {
-      "icon": "src/images/favicon1000.png"
-    }
-  }, "gatsby-plugin-sharp", "gatsby-transformer-sharp", {
-    resolve: 'gatsby-source-filesystem',
-    options: {
-      "name": "images",
-      "path": "./src/images/"
+  plugins: [
+    "gatsby-plugin-styled-components",
+    "gatsby-plugin-image",
+    "gatsby-plugin-sitemap",
+    {
+      resolve: "gatsby-plugin-manifest",
+      options: {
+        icon: "src/images/favicon1000.png",
+      },
     },
-    __key: "images"
-  }]
-};
+    "gatsby-plugin-sharp",
+    "gatsby-transformer-sharp",
+    {
+      resolve: "gatsby-source-filesystem",
+      options: {
+        name: "images",
+        path: "./src/images/",
+      },
+      __key: "images",
+    },
+  ],
+}
 
-export default config;
+export default config

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+import { useSiteMetadata } from "../hooks/useSiteMetadata"
+
+interface SEOProps {
+  title?: string
+  description?: string
+  pathname?: string
+  keywords?: string
+  children?: React.ReactNode
+}
+
+export const SEO = ({ title, description, pathname, keywords, children }: SEOProps) => {
+  const {
+    title: defaultTitle,
+    description: defaultDescription,
+    author,
+    creator,
+    type,
+    siteUrl,
+    keywords: defaultKeywords,
+    openGraphImage,
+    twitterImage,
+    twitterUsername,
+  } = useSiteMetadata()
+
+  const seo = {
+    title: title || defaultTitle,
+    description: (description || defaultDescription).replace(/\s+/g, " "),
+    author: author,
+    creator: creator,
+    type,
+    url: `${siteUrl}${pathname || ``}`,
+    keywords: (keywords
+      ? `${defaultKeywords}, ${keywords}`
+      : defaultKeywords
+    ).replace(/\s+/g, " "),
+    openGraphImage: `${siteUrl}${openGraphImage}`,
+    twitterImage: `${siteUrl}${twitterImage}`,
+    twitterUsername,
+  }
+
+  return (
+    <>
+      <title>{seo.title}</title>
+      <meta name="description" content={seo.description} />
+      <meta name="author" content={seo.author} />
+      <meta name="creator" content={seo.creator} />
+      <meta name="keywords" content={seo.keywords} />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta property="og:title" content={seo.title} />
+      <meta property="og:description" content={seo.description} />
+      <meta property="og:type" content={seo.type} />
+      <meta property="og:url" content={seo.url} />
+      <meta property="og:image" content={seo.openGraphImage} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={seo.title} />
+      <meta name="twitter:description" content={seo.description} />
+      <meta name="twitter:url" content={seo.url} />
+      <meta name="twitter:image" content={seo.twitterImage} />
+      <meta
+        name="twitter:image:alt"
+        content="Lorem ipsum dolor sit amet, consectetur tincidunt."
+      />
+      <meta name="twitter:site" content={seo.twitterUsername} />
+      <meta name="twitter:creator" content={seo.twitterUsername} />
+      {children}
+    </>
+  )
+}

--- a/src/hooks/useSiteMetadata.ts
+++ b/src/hooks/useSiteMetadata.ts
@@ -1,0 +1,24 @@
+import { graphql, useStaticQuery } from "gatsby"
+
+export const useSiteMetadata = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
+          author
+          creator
+          type
+          siteUrl
+          keywords
+          openGraphImage
+          twitterImage
+          twitterUsername
+        }
+      }
+    }
+  `)
+
+  return data.site.siteMetadata
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { HeadFC } from "gatsby"
+import { SEO } from "../components/SEO"
 import { GlobalStyle } from "../components/styles/GlobalStyles.styled"
 import NavBar from "../components/NavBar"
 import { StyledText } from "../components/styles/404Page.styled"
@@ -18,4 +19,4 @@ const NotFoundPage = () => {
 
 export default NotFoundPage
 
-export const Head: HeadFC = () => <title>Mika's Portfolio</title>
+export const Head: HeadFC = () => <SEO pathname={window.location.pathname} />

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { HeadFC } from "gatsby"
+import { SEO } from "../components/SEO"
 import { GlobalStyle } from "../components/styles/GlobalStyles.styled"
 import NavBar from "../components/NavBar"
 import {
@@ -49,4 +50,6 @@ const AboutPage = () => {
 
 export default AboutPage
 
-export const Head: HeadFC = () => <title>Mika's Portfolio</title>
+export const Head: HeadFC = () => (
+  <SEO pathname="/about" keywords="mika, okabe, mika okabe" />
+)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { HeadFC } from "gatsby"
+import { SEO } from "../components/SEO"
 import { GlobalStyle } from "../components/styles/GlobalStyles.styled"
 import NavBar from "../components/NavBar"
 import SpeakerDeck from "../components/SpeakerDeck"
@@ -29,4 +30,4 @@ const IndexPage = () => {
 
 export default IndexPage
 
-export const Head: HeadFC = () => <title>Mika's Portfolio</title>
+export const Head: HeadFC = () => <SEO keywords="speakerdeck" />

--- a/src/pages/personal.tsx
+++ b/src/pages/personal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { HeadFC } from "gatsby"
+import { SEO } from "../components/SEO"
 import { GlobalStyle } from "../components/styles/GlobalStyles.styled"
 import NavBar from "../components/NavBar"
 import { StyledMediaContainer } from "../components/styles/PersonalPage.styled"
@@ -49,4 +50,4 @@ const PersonalPage = () => {
 
 export default PersonalPage
 
-export const Head: HeadFC = () => <title>Mika's Portfolio</title>
+export const Head: HeadFC = () => <SEO pathname="/personal" />

--- a/src/pages/sketches.tsx
+++ b/src/pages/sketches.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import type { HeadFC } from "gatsby"
+import { SEO } from "../components/SEO"
 import { GlobalStyle } from "../components/styles/GlobalStyles.styled"
 import NavBar from "../components/NavBar"
 import { StyledSketchesContainer } from "../components/styles/SketchesPage.styled"
@@ -45,4 +46,6 @@ const SketchesPage = () => {
 
 export default SketchesPage
 
-export const Head: HeadFC = () => <title>Mika's Portfolio</title>
+export const Head: HeadFC = () => (
+  <SEO pathname="/sketches" keywords="sketches, sketch book" />
+)


### PR DESCRIPTION
Adds SEO and metadata by:
- Defining the site's metadata with the Gatsby Config API
- Implementing custom React hook that gets site's metadata using GraphQL
- Implementing React component that creates HTML meta tags
- Using Gatsby Head API to add the React component, and thus the meta tags, to the HTML head tag for each page

The SEO component and metadata are also configured for OpenGraph and Twitter cards to enhance how this website may be shared online