### PR TITLE
Changed behavior for minimum of 1 column

### DIFF
--- a/src/components/MasonryLayout.tsx
+++ b/src/components/MasonryLayout.tsx
@@ -44,9 +44,7 @@ const MasonryLayout = ({
 
   useLayoutEffect(() => {
     const childrenArray = React.Children.toArray(children)
-    if (numColumns <= 0) {
-      setColumns([[]])
-    } else if (numColumns === 1) {
+    if (numColumns <= 1) {
       setColumns([childrenArray])
     } else if (numColumns === childrenArray.length) {
       setColumns(childrenArray.map((element) => [element]))

--- a/src/components/styles/MasonryLayout.styled.ts
+++ b/src/components/styles/MasonryLayout.styled.ts
@@ -32,7 +32,7 @@ export const StyledMasonryColumn = styled.div<{
   spacing: number
 }>`
   /* Box model properties */
-  width: ${(props) => props.columnWidth}px;
+  max-width: ${(props) => props.columnWidth}px;
   margin-right: ${(props) => props.spacing}px;
 
   /* Layout properties */


### PR DESCRIPTION
The masonry-like layout component now has a minimum of 1 column. When the component is less than the width set by its `columnWidth` prop, it will have 1 column instead of 0 columns. This column shares the same width as the masonry-like layout component

Closes #35