### PR TITLE
Fixed incorrect icon being shown

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -99,9 +99,9 @@ const NavBar = () => {
         ))}
         <StyledMenuIconContainer>
           {showMenu ? (
-            <MenuRounded onClick={() => setShowMenu(false)} />
+            <CloseRounded onClick={() => setShowMenu(false)} />
           ) : (
-            <CloseRounded onClick={() => setShowMenu(true)} />
+            <MenuRounded onClick={() => setShowMenu(true)} />
           )}
         </StyledMenuIconContainer>
         <StyledMobileWebsiteTitle>


### PR DESCRIPTION
Fixes incorrect icon being shown on the mobile-version of the navigation bar. The close icon was being shown when the menu was not expanded, and the menu icon was being shown when the menu was expanded