### PR TITLE
Updated masonry-like layout width on Personal page

### DIFF
--- a/src/pages/sketches.tsx
+++ b/src/pages/sketches.tsx
@@ -32,7 +32,7 @@ const SketchesPage = (): React.JSX.Element => {
       <GlobalStyle />
       <NavBar />
       <StyledSketchesContainer>
-        <MasonryLayout columnWidth={300} spacing={10}>
+        <MasonryLayout columnWidth={400} spacing={10}>
           {images.map((image, index) => (
             <ClickableImage key={index} src={image} alt={`Sketch ${index}`} />
           ))}


### PR DESCRIPTION
Updates the masonry-like layout on the "Personal" page to have columns of 400px rather than 300px, increasing the visibility of the images